### PR TITLE
에러 관련 다이얼로그 추가 및 배포 로그인 관련 에러 수정

### DIFF
--- a/src/app/[teamId]/schedule/[tab]/board/StatusList.tsx
+++ b/src/app/[teamId]/schedule/[tab]/board/StatusList.tsx
@@ -152,16 +152,12 @@ export default function StatusList({ status, onDeleteStatus }: Props) {
       <div className="flex flex-col gap-2 mt-5">
         {filteredTasks.map((task, index) => (
           <div
-            key={`${task.id}-${index}`}
+            key={task.id}
             draggable
             onDragStart={(event) => handleDragStart(event, task)}
             onDragOver={(event) => handleDragOverTask(event, index)}
           >
-            <Task
-              key={`${task.id}-${index}`}
-              task={task}
-              onClick={() => handleEditTask(task)}
-            />
+            <Task task={task} onClick={() => handleEditTask(task)} />
           </div>
         ))}
       </div>

--- a/src/app/[teamId]/schedule/[tab]/board/StatusList.tsx
+++ b/src/app/[teamId]/schedule/[tab]/board/StatusList.tsx
@@ -122,8 +122,9 @@ export default function StatusList({ status, onDeleteStatus }: Props) {
     );
     try {
       await Promise.all(tasksToUpdate.map((task) => onUpdateTask(task)));
-    } catch (error) {
-      console.error(error);
+    } catch (error: any) {
+      setIsErrorDialogOpen(true);
+      setErrorMessage(error.message);
     }
   };
 

--- a/src/app/[teamId]/schedule/[tab]/calendar/Agenda.tsx
+++ b/src/app/[teamId]/schedule/[tab]/calendar/Agenda.tsx
@@ -26,8 +26,8 @@ export default function Agenda({ tasks, year, month }: Props) {
           이벤트가 없습니다 {year}-{String(month).padStart(2, "0")}
         </p>
       ) : (
-        filtered.map((task, index) => (
-          <div key={`${task.id}-${index}`} className="flex gap-2 items-center">
+        filtered.map((task) => (
+          <div key={task.id} className="flex gap-2 items-center">
             <div
               className="w-5 h-5 rounded-sm"
               style={{ backgroundColor: task.color }}

--- a/src/app/[teamId]/schedule/tabs/Tab.tsx
+++ b/src/app/[teamId]/schedule/tabs/Tab.tsx
@@ -1,7 +1,6 @@
 import { useRouter, useParams } from "next/navigation";
 import clsx from "clsx";
 import { useTabsContext } from "@/app/[teamId]/schedule/tabs/TabsContext";
-import { useEffect } from "react";
 
 type Props = {
   tab: string;

--- a/src/app/[teamId]/schedule/tabs/Tabs.tsx
+++ b/src/app/[teamId]/schedule/tabs/Tabs.tsx
@@ -8,8 +8,8 @@ export default function Tabs() {
 
   return (
     <div className="pt-12 pl-[70px] bg-background-tabs">
-      {tabList.map((tab, index) => (
-        <Tab key={`${tab}-${index}`} tab={tab} />
+      {tabList.map((tab) => (
+        <Tab key={tab} tab={tab} />
       ))}
     </div>
   );

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -16,12 +16,14 @@ export async function POST(request: Request): Promise<NextResponse> {
     const redirectUrl = new URL(`/mypage/${decodedToken.uid}`, request.url);
     const response = NextResponse.redirect(redirectUrl, 303); //303: 쿠키설정 + GET 방식 리다이렉트
 
-    response.headers.set(
-      "Set-Cookie",
-      `session=${sessionCookie}; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=${
-        60 * 60 * 24 * 5
-      }`
-    );
+    response.cookies.set("session", sessionCookie, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge: 60 * 60 * 24 * 5, // 5일(초)
+      path: "/",
+    });
+
     return response;
   } catch (error) {
     console.error(error);

--- a/src/app/auth/[auth]/register/RegisterForm.tsx
+++ b/src/app/auth/[auth]/register/RegisterForm.tsx
@@ -39,8 +39,8 @@ export default function RegisterForm() {
       } else {
         router.push("/auth/login");
       }
-    } catch (error) {
-      setServerMessage("오류가 발생했습니다.");
+    } catch (error: any) {
+      setServerMessage(error.message);
     } finally {
       setIsLoading(false);
     }

--- a/src/app/auth/[auth]/register/RegisterForm.tsx
+++ b/src/app/auth/[auth]/register/RegisterForm.tsx
@@ -40,7 +40,6 @@ export default function RegisterForm() {
         router.push("/auth/login");
       }
     } catch (error) {
-      console.error(error);
       setServerMessage("오류가 발생했습니다.");
     } finally {
       setIsLoading(false);

--- a/src/app/mypage/[uid]/TeamScheduleCard.tsx
+++ b/src/app/mypage/[uid]/TeamScheduleCard.tsx
@@ -19,8 +19,8 @@ export default function TeamScheduleCard({ teamName, teamId }: Props) {
         <div>{teamName}</div>
         <div>
           {/* TODO: member 관련 정보 api 생성 + icon, 3명 이상 icon 처리, 나머지 +n */}
-          {/* {members.map((member, index) => (
-            <span key={`${member.id}-${index}`}>
+          {/* {members.map((member) => (
+            <span key={member.id}>
             </span>
           ))} */}
         </div>

--- a/src/app/mypage/[uid]/TeamScheduleList.tsx
+++ b/src/app/mypage/[uid]/TeamScheduleList.tsx
@@ -33,9 +33,9 @@ export default function TeamScheduleList() {
   return (
     <div className="pt-16 px-8">
       <AddNewButton type="team" onClick={openModal} />
-      {teams.map((team, index) => (
+      {teams.map((team) => (
         <TeamScheduleCard
-          key={`${team.id}-${index}`}
+          key={team.id}
           teamName={team.teamName}
           teamId={team.id}
           members={team.members}

--- a/src/components/common/Editor.tsx
+++ b/src/components/common/Editor.tsx
@@ -45,6 +45,8 @@ export default function Editor({ onClose, statusId, editingTask }: Props) {
   const [taskFormData, setTaskFormData] = useState<TaskType>(initialFormData);
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
   const [openConfirmDeleteDialog, setOpenConfirmDeleteDialog] = useState(false);
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>("");
   const { onCreateNewTask, taskList, onUpdateTask, onDeleteTask } =
     useContentsContext();
   const [formState, formAction] = useActionState<TaskFormStatusType, FormData>(
@@ -115,7 +117,8 @@ export default function Editor({ onClose, statusId, editingTask }: Props) {
       setOpenConfirmDialog(false);
       onClose();
     } catch (error: any) {
-      console.error(error.message);
+      setIsErrorDialogOpen(true);
+      setErrorMessage(error.message);
     }
   };
 
@@ -126,7 +129,8 @@ export default function Editor({ onClose, statusId, editingTask }: Props) {
       setOpenConfirmDeleteDialog(false);
       onClose();
     } catch (error: any) {
-      console.error(error.message);
+      setIsErrorDialogOpen(true);
+      setErrorMessage(error.message);
     }
   };
 
@@ -253,6 +257,14 @@ export default function Editor({ onClose, statusId, editingTask }: Props) {
           onConfrim={handleDeleteTask}
           confirmText="Delete"
           contentText={confirmTaskDeleteMessage}
+        />
+      )}
+
+      {isErrorDialogOpen && (
+        <ConfirmDialog
+          onClose={() => setIsErrorDialogOpen(false)}
+          contentText={errorMessage}
+          closeText="Confirm"
         />
       )}
     </form>

--- a/src/components/dropdown/MenuList.tsx
+++ b/src/components/dropdown/MenuList.tsx
@@ -16,10 +16,10 @@ export default function MenuList({ onClick, onClose, list, top, left }: Props) {
   return (
     <Dropdown onClose={onClose} top={top} left={left}>
       <ul>
-        {list.map((item, index) => (
+        {list.map((item) => (
           <li
             role="button"
-            key={`${item}-${index}`}
+            key={item}
             onClick={(event) => onClick(event)}
             tabIndex={0}
             onKeyUp={(event: KeyboardEvent<HTMLLIElement>) => {


### PR DESCRIPTION
- key값에 불필요하게 들어갔던 index 제거
- 클라이언트 처리 코드에서 error 시 다이얼로그에 에러 표시하게 수정
- 배포 로그인 관련 set-cookie가 응답헤더에 찍히지 않는 문제 -> 기존 header를 통해 cookie를 저장하는 방식은 set-cookie가 정상 반영되지 않는 가능성이 있어서 NextResponse.cookies.set()을 사용해 쿠키 확실하게 저장하는 방식으로 수정