### PR TITLE
Refactor/review code2

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -5,7 +5,7 @@ import "@/lib/firebase";
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const { token, stayLoggedIn } = await request.json();
-    //firebase admin를 통해 유효한 토큰인지 검증
+
     const decodedToken = await getAuth().verifyIdToken(token);
 
     const baseUrl = request.nextUrl.origin;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ import "@/lib/firebase";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { token } = await request.json();
+    const { token, stayLoggedIn } = await request.json();
     //firebase admin를 통해 유효한 토큰인지 검증
     const decodedToken = await getAuth().verifyIdToken(token);
 
@@ -25,7 +25,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      maxAge: 60 * 60 * 24 * 5, // 5일(초)
+      maxAge: stayLoggedIn ? 60 * 60 * 24 * 5 : undefined, // 5일(초)
       path: "/",
     });
 

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     return NextResponse.json(
       { error: "로그아웃 처리 중 서버 오류가 발생했습니다." },
-      { status: 500 }
+      { status: error.status }
     );
   }
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -14,7 +14,6 @@ export async function POST(_reqeust: NextRequest) {
 
     return response;
   } catch (error: any) {
-    console.error(error);
     return NextResponse.json(
       { error: "로그아웃 처리 중 서버 오류가 발생했습니다." },
       { status: 500 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export async function POST(_reqeust: NextRequest) {
+export async function POST(request: NextRequest) {
   try {
-    const response = await NextResponse.json({ success: true });
-
+    const response = NextResponse.redirect(new URL("/auth/login", request.url));
     response.cookies.set("session", "", {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "strict",
-      path: "/",
       maxAge: 0,
+      path: "/",
     });
 
     return response;

--- a/src/app/api/teams/[teamId]/tasks/route.ts
+++ b/src/app/api/teams/[teamId]/tasks/route.ts
@@ -51,7 +51,7 @@ export async function POST(
       updatedAt: Date.now(),
     });
 
-    return NextResponse.json({ id: docRef.id, ...data }, { status: 201 }); //201 -> created 요청
+    return NextResponse.json({ id: docRef.id, ...data }, { status: 201 });
   } catch (error: any) {
     console.error(error);
     return NextResponse.json(

--- a/src/app/auth/[auth]/login/LoginForm.tsx
+++ b/src/app/auth/[auth]/login/LoginForm.tsx
@@ -44,17 +44,13 @@ export default function LoginForm() {
     }
   );
 
-  const loginWithEmail = async (
-    email: string,
-    password: string,
-    stayLoggedIn: boolean
-  ) => {
+  const loginWithEmail = async (email: string, password: string) => {
     if (!auth) return;
     setIsLoading(true);
     try {
       await setPersistence(
         auth,
-        stayLoggedIn ? browserSessionPersistence : inMemoryPersistence
+        isLoggedIn ? browserSessionPersistence : inMemoryPersistence
       );
 
       const result = await signInWithEmailAndPassword(auth, email, password);
@@ -65,7 +61,7 @@ export default function LoginForm() {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token, stayLoggedIn }),
+          body: JSON.stringify({ token, stayLoggedIn: isLoggedIn }),
           credentials: "include",
         }
       );
@@ -110,10 +106,8 @@ export default function LoginForm() {
   };
 
   const onSubmit = async (data: LogInFormType) => {
-    if (isLoggedIn) {
-    }
     if (data.email && data.password)
-      await loginWithEmail(data.email, data.password, isLoggedIn);
+      await loginWithEmail(data.email, data.password);
   };
 
   return (

--- a/src/app/invite/[teamId]/[invitationId]/expired/page.tsx
+++ b/src/app/invite/[teamId]/[invitationId]/expired/page.tsx
@@ -1,0 +1,7 @@
+export default function ExpiredPage() {
+  return (
+    <div className="text-center p-8 text-white">
+      <h1>해당 링크의 유효기간이 만료되었습니다.</h1>
+    </div>
+  );
+}

--- a/src/app/invite/[teamId]/[invitationId]/schedule/board/page.tsx
+++ b/src/app/invite/[teamId]/[invitationId]/schedule/board/page.tsx
@@ -27,6 +27,7 @@ export default async function InviteBoardPage({ params }: Props) {
   if (!invitationSnap.exists) return notFound();
 
   const inviteeData = invitationSnap.data()!;
+  // TODO: 만료페이지 생성
   if (inviteeData.expiresAt < Date.now()) return notFound();
 
   if (inviteeData.accepted) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { ReactNode } from "react";
 import Header from "@/components/layout/Header";
 import "./globals.css";
+import { getSessionUid } from "@/lib/server/auth";
 
 type Props = Readonly<{
   children: ReactNode;
@@ -15,11 +16,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: Props) {
+export default async function RootLayout({ children }: Props) {
+  const uid = await getSessionUid();
   return (
     <html lang="en">
       <body className="bg-background-startContents">
-        <Header />
+        <Header uid={uid} />
         {children}
         <div id="portal"></div>
       </body>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,83 +1,40 @@
 "use client";
-import { useState, useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { signOut, onAuthStateChanged, User } from "firebase/auth";
-import { auth } from "@/lib/firebaseClient";
-import IconButton from "@/components/common/button/IconButton";
-import profileIcon from "@/assets/person-circle.svg";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import ProfileIcon from "@/assets/person-circle.svg";
 
-export default function Header() {
-  const [user, setUser] = useState<User | null>(null);
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
-
-  const params = useParams();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!auth) return;
-    const unsubscribe = onAuthStateChanged(auth, (u) => {
-      if (isLoggingOut) return;
-      if (isLoggingIn) {
-        if (u) {
-          setUser(u);
-          setIsLoggingIn(false);
-        }
-        return;
-      }
-      setUser(u);
-    });
-    return () => unsubscribe();
-  }, [isLoggingOut, isLoggingIn]);
-
-  const handleLogin = () => {
-    router.push("/auth/login");
-    setIsLoggingIn(true);
-  };
-
-  const handleLogout = async () => {
-    if (!auth) return;
-    setIsLoggingOut(true);
-    try {
-      await signOut(auth);
-      await fetch("/api/auth/logout", { method: "POST" });
-      setUser(null);
-      await router.push("/auth/login");
-    } finally {
-      setIsLoggingOut(false);
-    }
-  };
+interface Props {
+  uid: string | null;
+}
+export default function Header({ uid }: Props) {
+  const path = usePathname();
 
   return (
-    <div className="flex justify-between py-[51px] px-[45px] text-4xl font-extrabold text-white bg-headerBlue">
-      <h1>My Scheduler</h1>
-      <div className="text-base">
-        {user && (
-          <div className="flex gap-3">
-            <button
-              onClick={handleLogout}
-              className="underline text-sm font-extralight"
-              disabled={isLoggingOut}
-            >
-              {isLoggingOut ? "Logging out..." : "Log out"}
-            </button>
-            <IconButton
-              icon={profileIcon}
-              size="md"
-              onClick={async () => await router.push(`/mypage/${user.uid}`)}
-              alt="profile icon"
-            />
-          </div>
-        )}
-        {!user && params.auth !== "login" && (
-          <button
-            onClick={handleLogin}
-            className="underline text-sm font-extralight"
+    <header className="flex justify-between items-center p-6 bg-headerBlue text-white">
+      <h1 className="text-2xl font-bold">My Scheduler</h1>
+      <nav className="space-x-4">
+        {uid ? (
+          <>
+            <div className="flex items-center gap-3">
+              <form action="/api/auth/logout" method="post" className="inline">
+                <button type="submit" className="underline">
+                  Log out
+                </button>
+              </form>
+              <Link href={`/mypage/${uid}`} className="underline">
+                <ProfileIcon width={24} height={24} />
+              </Link>
+            </div>
+          </>
+        ) : (
+          <Link
+            href={`/auth/login?callbackUrl=${encodeURIComponent(path)}`}
+            className="underline"
           >
             Log in
-          </button>
+          </Link>
         )}
-      </div>
-    </div>
+      </nav>
+    </header>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { signOut, onAuthStateChanged, User } from "firebase/auth";
 import { auth } from "@/lib/firebaseClient";
 import IconButton from "@/components/common/button/IconButton";
@@ -11,6 +11,7 @@ export default function Header() {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
 
+  const params = useParams();
   const router = useRouter();
 
   useEffect(() => {
@@ -51,7 +52,7 @@ export default function Header() {
     <div className="flex justify-between py-[51px] px-[45px] text-4xl font-extrabold text-white bg-headerBlue">
       <h1>My Scheduler</h1>
       <div className="text-base">
-        {user ? (
+        {user && (
           <div className="flex gap-3">
             <button
               onClick={handleLogout}
@@ -67,13 +68,13 @@ export default function Header() {
               alt="profile icon"
             />
           </div>
-        ) : (
+        )}
+        {!user && params.auth !== "login" && (
           <button
             onClick={handleLogin}
             className="underline text-sm font-extralight"
-            disabled={isLoggingIn}
           >
-            {isLoggingIn ? "Loading..." : "Log in"}
+            Log in
           </button>
         )}
       </div>


### PR DESCRIPTION
- Header log out 방식 수정
  - 문제: onAuthStateChanged에 의존해서 사용자 상태를 바라봤던 문제 => 첫 렌더링 때 user===null 상태로 항상 Log in 버튼만 표시. 서버에 세션 쿠키가 있어도 fireabse client sdk(auth)는 모르는 문제때문에 제대로 login, log out 변경이 이루어지지 않음
  - Header의 상위인 서버컴포넌트 layout에서 uid를 조회하여 props로 전달하여 처리
- 고민했던 부분
  - Header.tsx의 로그아웃 form에서 useActionState을 사용하여 처리를 고민했으나, 로그아웃의 경우 성공 여부를 보여줄 필요가 없을 것 같아 html에서 제공하는 action 사용해서 로그아웃 api route로 post 요청하고 login으로 redirect 시키는 흐름으로 진행
- logout api route에서 로그아웃 시 쿠키 삭제가 목적이므로 기존에 cookie 생성 시와 동일하게 httpOnly 등 처리했던 몇가지 요소들 제거