### PR TITLE
Header에 login 상태 반영문제 수정

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ import "@/lib/firebase";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { token, stayLoggedIn } = await request.json();
+    const { token, isLoggedIn } = await request.json();
 
     const decodedToken = await getAuth().verifyIdToken(token);
 
@@ -25,7 +25,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      maxAge: stayLoggedIn ? 60 * 60 * 24 * 5 : undefined, // 5일(초)
+      maxAge: isLoggedIn ? 60 * 60 * 24 * 5 : undefined, // 5일(초)
       path: "/",
     });
 

--- a/src/app/auth/[auth]/login/LoginForm.tsx
+++ b/src/app/auth/[auth]/login/LoginForm.tsx
@@ -66,8 +66,10 @@ export default function LoginForm() {
         }
       );
 
-      if (response.ok && response.redirected) router.replace(response.url);
-      else {
+      if (response.ok && response.redirected) {
+        router.replace(response.url);
+        router.refresh();
+      } else {
         const json = await response.json();
         throw new Error(json.error || "로그인에 실패했습니다.");
       }

--- a/src/app/auth/[auth]/login/LoginForm.tsx
+++ b/src/app/auth/[auth]/login/LoginForm.tsx
@@ -61,7 +61,7 @@ export default function LoginForm() {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token, stayLoggedIn: isLoggedIn }),
+          body: JSON.stringify({ token, isLoggedIn }),
           credentials: "include",
         }
       );

--- a/src/hooks/useDropdownToggle.test.ts
+++ b/src/hooks/useDropdownToggle.test.ts
@@ -3,7 +3,6 @@ import { useDropdownToggle, useDropdownApply } from "@/hooks/useDropdown";
 import { Priority } from "@/types/scheduleType";
 
 const HIGH: Priority = "High";
-const MEDIUM: Priority = "Medium";
 const LOW: Priority = "Low";
 
 describe("useDropdownToggle 훅 테스트", () => {

--- a/src/hooks/useDropdownToggle.test.ts
+++ b/src/hooks/useDropdownToggle.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from "@testing-library/react";
+import { useDropdownToggle } from "@/hooks/useDropdown";
+
+describe("useDropdownToggle 훅 테스트", () => {
+  it("dropdownPosition의 초기 상태는 null이다", () => {
+    const { result } = renderHook(() => useDropdownToggle());
+    expect(result.current.dropdownPosition).toBeNull();
+  });
+
+  it("toggleDropdown 호출 시 getBoundingClientRect 값에 따라 dropdownPosition이 설정된다", () => {
+    const { result } = renderHook(() => useDropdownToggle());
+    const mockEvent = {
+      currentTarget: {
+        getBoundingClientRect: jest.fn(() => ({
+          left: 345,
+          bottom: 265,
+        })),
+      },
+    } as any;
+
+    act(() => {
+      result.current.toggleDropdown(mockEvent);
+    });
+
+    expect(result.current.dropdownPosition).toEqual({ top: 265, left: 345 }); //bottom을 top에 대입
+  });
+
+  it("열려있는 상태에서 toggleDropdown 호출 시 dropdownPosition은 null이 되어 토글된다", () => {
+    const { result } = renderHook(() => useDropdownToggle());
+    const mockEvent = {
+      currentTarget: {
+        getBoundingClientRect: jest.fn(() => ({
+          left: 345,
+          bottom: 265,
+        })),
+      },
+    } as any;
+
+    act(() => {
+      result.current.toggleDropdown(mockEvent);
+    });
+    expect(result.current.dropdownPosition).toEqual({ top: 265, left: 345 });
+
+    act(() => {
+      result.current.toggleDropdown(mockEvent);
+    });
+    expect(result.current.dropdownPosition).toBeNull();
+  });
+});

--- a/src/hooks/useDropdownToggle.test.ts
+++ b/src/hooks/useDropdownToggle.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from "@testing-library/react";
-import { useDropdownToggle } from "@/hooks/useDropdown";
+import { useDropdownToggle, useDropdownApply } from "@/hooks/useDropdown";
+import { Priority } from "@/types/scheduleType";
+
+const HIGH: Priority = "High";
+const MEDIUM: Priority = "Medium";
+const LOW: Priority = "Low";
 
 describe("useDropdownToggle 훅 테스트", () => {
   it("dropdownPosition의 초기 상태는 null이다", () => {
@@ -44,6 +49,59 @@ describe("useDropdownToggle 훅 테스트", () => {
     act(() => {
       result.current.toggleDropdown(mockEvent);
     });
+    expect(result.current.dropdownPosition).toBeNull();
+  });
+});
+
+describe("useDropdownApply 훅 테스트", () => {
+  let result: { current: any };
+  const onApplyMock = jest.fn();
+
+  const mockEvent = (bottom = 100, left = 50) => {
+    return {
+      currentTarget: {
+        getBoundingClientRect: () => ({ left, bottom }),
+      },
+    } as any;
+  };
+
+  beforeEach(() => {
+    const hook = renderHook(() => useDropdownApply({ onApply: onApplyMock }));
+    result = hook.result;
+  });
+
+  it("초기상태의 dropdownPosition은 null, selectedPriorities는 빈 배열이다", () => {
+    expect(result.current.dropdownPosition).toBeNull();
+    expect(result.current.selectedPriorities).toEqual([]);
+    expect(onApplyMock).not.toHaveBeenCalled();
+  });
+
+  it("openDropdown 호출 시 dropdownPosition이 셋팅되고 togglePriorites가 selectedPriorities로 셋팅된다", () => {
+    act(() => {
+      result.current.openDropdown(mockEvent(120, 80));
+    });
+    expect(result.current.dropdownPosition).toEqual({ top: 120, left: 80 });
+    expect(result.current.selectedPriorities).toEqual([]);
+  });
+
+  it("togglePriority함수 호출시 togglePriorities가 호출되어 토글된다.", () => {
+    act(() => result.current.openDropdown(mockEvent()));
+    act(() => result.current.togglePriority(HIGH));
+    expect(result.current.selectedPriorities).toEqual([HIGH]);
+
+    act(() => result.current.togglePriority(HIGH));
+    expect(result.current.selectedPriorities).toEqual([]);
+  });
+
+  it("applyPriorities 호출 시 onApply에 priorities 문자열이 전달된다", () => {
+    act(() => result.current.openDropdown(mockEvent()));
+
+    act(() => {
+      result.current.togglePriority(HIGH);
+      result.current.togglePriority(LOW);
+    });
+    act(() => result.current.applyPriorities());
+    expect(onApplyMock).toHaveBeenCalledWith([HIGH, LOW]);
     expect(result.current.dropdownPosition).toBeNull();
   });
 });

--- a/src/hooks/useDropdownToggle.test.ts
+++ b/src/hooks/useDropdownToggle.test.ts
@@ -6,22 +6,28 @@ const HIGH: Priority = "High";
 const LOW: Priority = "Low";
 
 describe("useDropdownToggle 훅 테스트", () => {
+  let result: { current: any };
+
+  const mockEvent = {
+    currentTarget: {
+      getBoundingClientRect: jest.fn(() => ({
+        left: 345,
+        bottom: 265,
+      })),
+    },
+  } as any;
+
+  beforeEach(() => {
+    const hook = renderHook(() => useDropdownToggle());
+    result = hook.result;
+  });
+
   it("dropdownPosition의 초기 상태는 null이다", () => {
     const { result } = renderHook(() => useDropdownToggle());
     expect(result.current.dropdownPosition).toBeNull();
   });
 
   it("toggleDropdown 호출 시 getBoundingClientRect 값에 따라 dropdownPosition이 설정된다", () => {
-    const { result } = renderHook(() => useDropdownToggle());
-    const mockEvent = {
-      currentTarget: {
-        getBoundingClientRect: jest.fn(() => ({
-          left: 345,
-          bottom: 265,
-        })),
-      },
-    } as any;
-
     act(() => {
       result.current.toggleDropdown(mockEvent);
     });
@@ -30,16 +36,6 @@ describe("useDropdownToggle 훅 테스트", () => {
   });
 
   it("열려있는 상태에서 toggleDropdown 호출 시 dropdownPosition은 null이 되어 토글된다", () => {
-    const { result } = renderHook(() => useDropdownToggle());
-    const mockEvent = {
-      currentTarget: {
-        getBoundingClientRect: jest.fn(() => ({
-          left: 345,
-          bottom: 265,
-        })),
-      },
-    } as any;
-
     act(() => {
       result.current.toggleDropdown(mockEvent);
     });

--- a/src/hooks/useModal.test.ts
+++ b/src/hooks/useModal.test.ts
@@ -9,19 +9,15 @@ describe("useModal 훅 테스트", () => {
   });
 
   it("초기 오픈여부의 상태는 false이다", () => {
-    // const { result } = renderHook(() => useModal());
     expect(result.current.open).toBe(false);
   });
 
   it("openModal을 호출하면 open여부는 true가 된다", () => {
-    // const { result } = renderHook(() => useModal());
     act(() => result.current.openModal());
     expect(result.current.open).toBe(true);
   });
 
   it("closeModal을 호출하면 open여부는 false가 된다", () => {
-    // const { result } = renderHook(() => useModal());
-
     act(() => result.current.openModal());
     expect(result.current.open).toBe(true);
 

--- a/src/hooks/useModal.test.ts
+++ b/src/hooks/useModal.test.ts
@@ -2,30 +2,30 @@ import { renderHook, act } from "@testing-library/react";
 import { useModal } from "@/hooks/useModal";
 
 describe("useModal 훅 테스트", () => {
+  let result: { current: any };
+  beforeEach(() => {
+    const hook = renderHook(() => useModal());
+    result = hook.result;
+  });
+
   it("초기 오픈여부의 상태는 false이다", () => {
-    const { result } = renderHook(() => useModal());
+    // const { result } = renderHook(() => useModal());
     expect(result.current.open).toBe(false);
   });
 
   it("openModal을 호출하면 open여부는 true가 된다", () => {
-    const { result } = renderHook(() => useModal());
-    act(() => {
-      result.current.openModal();
-    });
+    // const { result } = renderHook(() => useModal());
+    act(() => result.current.openModal());
     expect(result.current.open).toBe(true);
   });
 
   it("closeModal을 호출하면 open여부는 false가 된다", () => {
-    const { result } = renderHook(() => useModal());
+    // const { result } = renderHook(() => useModal());
 
-    act(() => {
-      result.current.openModal();
-    });
+    act(() => result.current.openModal());
     expect(result.current.open).toBe(true);
 
-    act(() => {
-      result.current.closeModal();
-    });
+    act(() => result.current.closeModal());
     expect(result.current.open).toBe(false);
   });
 });

--- a/src/hooks/useModal.test.ts
+++ b/src/hooks/useModal.test.ts
@@ -1,0 +1,31 @@
+import { renderHook, act } from "@testing-library/react";
+import { useModal } from "@/hooks/useModal";
+
+describe("useModal 훅 테스트", () => {
+  it("초기 오픈여부의 상태는 false이다", () => {
+    const { result } = renderHook(() => useModal());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("openModal을 호출하면 open여부는 true가 된다", () => {
+    const { result } = renderHook(() => useModal());
+    act(() => {
+      result.current.openModal();
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  it("closeModal을 호출하면 open여부는 false가 된다", () => {
+    const { result } = renderHook(() => useModal());
+
+    act(() => {
+      result.current.openModal();
+    });
+    expect(result.current.open).toBe(true);
+
+    act(() => {
+      result.current.closeModal();
+    });
+    expect(result.current.open).toBe(false);
+  });
+});

--- a/src/util/helper.test.ts
+++ b/src/util/helper.test.ts
@@ -1,5 +1,4 @@
 import { generateInviteCode } from "@/util/helper";
-import { randomBytes } from "crypto";
 
 jest.mock("crypto", () => ({
   randomBytes: jest.fn(() => Buffer.from("123456789012", "hex")),


### PR DESCRIPTION
- login 시 log in -> log out으로 변경 안되는 문제 수정
  - Header를 서버컴포넌트로 변경해도 RootLayout이 속한 같은 세그먼트 안에서 router같은 client 네비게이션 동작으로 처리 시 해당 세그먼트를 다시 가져오지 않음 -> 새로고침이 없는 상황에서는 login을 해도 Header에 log in으로 노출됨.
  loginForm에서 router로 마이페이지 이동 이후 refresh 처리하여 새로고침 발생시켜 처리